### PR TITLE
Update kind-of from v2.x to v3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "kind-of": "^2.0.0",
+    "kind-of": "^3.0.2",
     "longest": "^1.0.1",
     "repeat-string": "^1.5.2"
   },


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.
